### PR TITLE
Extend Tr interface in sqlx/contract.go by missing methods

### DIFF
--- a/sqlx/contract.go
+++ b/sqlx/contract.go
@@ -28,7 +28,7 @@ type Tr interface {
 	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
 
 	sqlx.Queryer
-	QueryRow(query string, args ...any) *sql.Row
+	QueryRow(query string, args ...interface{}) *sql.Row
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 	NamedQuery(query string, arg interface{}) (*sqlx.Rows, error)
 

--- a/sqlx/contract.go
+++ b/sqlx/contract.go
@@ -15,18 +15,20 @@ import (
 type Tr interface {
 	sqlx.ExtContext
 
+	sqlx.Preparer
 	Preparex(query string) (*sqlx.Stmt, error)
 	PreparexContext(ctx context.Context, query string) (*sqlx.Stmt, error)
-	PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error)
 	PrepareNamed(query string) (*sqlx.NamedStmt, error)
+	PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error)
 
+	sqlx.Execer
 	MustExec(query string, args ...interface{}) sql.Result
 	MustExecContext(ctx context.Context, query string, args ...interface{}) sql.Result
-	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
 	NamedExec(query string, arg interface{}) (sql.Result, error)
+	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
 
-	Queryx(query string, args ...interface{}) (*sqlx.Rows, error)
-	QueryRowx(query string, args ...interface{}) *sqlx.Row
+	sqlx.Queryer
+	QueryRow(query string, args ...any) *sql.Row
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 	NamedQuery(query string, arg interface{}) (*sqlx.Rows, error)
 


### PR DESCRIPTION
Thank you for the module, I use it in my Graduate Project with sqlx, and it's really helpful for me

I noticed that the trm/sqlx.Tr lacks several methods that exist in sqlx.Tx and sqlx.DB and decided to add them