### PR TITLE
fix: replace russian С to english C in trm.CtxManager type

### DIFF
--- a/drivers/goredis8/context.go
+++ b/drivers/goredis8/context.go
@@ -14,11 +14,11 @@ var DefaultCtxGetter = NewCtxGetter(trmcontext.DefaultManager)
 
 // CtxGetter gets goredis8.Pipeliner from trm.СtxManager by casting trm.Transaction to redis.UniversalClient.
 type CtxGetter struct {
-	ctxManager trm.СtxManager
+	ctxManager trm.CtxManager
 }
 
 // NewCtxGetter returns *CtxGetter to get Cmdable from context.Context.
-func NewCtxGetter(c trm.СtxManager) *CtxGetter {
+func NewCtxGetter(c trm.CtxManager) *CtxGetter {
 	return &CtxGetter{ctxManager: c}
 }
 

--- a/drivers/gorm/context.go
+++ b/drivers/gorm/context.go
@@ -14,11 +14,11 @@ var DefaultCtxGetter = NewCtxGetter(trmcontext.DefaultManager)
 
 // CtxGetter gets Tr from trm.СtxManager by casting trm.Transaction to *gorm.DB.
 type CtxGetter struct {
-	ctxManager trm.СtxManager
+	ctxManager trm.CtxManager
 }
 
 // NewCtxGetter returns *CtxGetter to get *gorm.DB from context.Context.
-func NewCtxGetter(c trm.СtxManager) *CtxGetter {
+func NewCtxGetter(c trm.CtxManager) *CtxGetter {
 	return &CtxGetter{ctxManager: c}
 }
 

--- a/drivers/mongo/context.go
+++ b/drivers/mongo/context.go
@@ -14,11 +14,11 @@ var DefaultCtxGetter = NewCtxGetter(trmcontext.DefaultManager)
 
 // CtxGetter gets Tr from trm.СtxManager by casting trm.Transaction to Tr.
 type CtxGetter struct {
-	ctxManager trm.СtxManager
+	ctxManager trm.CtxManager
 }
 
 // NewCtxGetter returns *CtxGetter to get Tr from context.Context.
-func NewCtxGetter(c trm.СtxManager) *CtxGetter {
+func NewCtxGetter(c trm.CtxManager) *CtxGetter {
 	return &CtxGetter{ctxManager: c}
 }
 

--- a/drivers/pgxv4/context.go
+++ b/drivers/pgxv4/context.go
@@ -12,11 +12,11 @@ var DefaultCtxGetter = NewCtxGetter(trmcontext.DefaultManager)
 
 // CtxGetter gets Tr from trm.СtxManager by casting trm.Transaction to Tr.
 type CtxGetter struct {
-	ctxManager trm.СtxManager
+	ctxManager trm.CtxManager
 }
 
 // NewCtxGetter returns *CtxGetter to get Tr from context.Context.
-func NewCtxGetter(c trm.СtxManager) *CtxGetter {
+func NewCtxGetter(c trm.CtxManager) *CtxGetter {
 	return &CtxGetter{ctxManager: c}
 }
 

--- a/drivers/pgxv5/context.go
+++ b/drivers/pgxv5/context.go
@@ -12,11 +12,11 @@ var DefaultCtxGetter = NewCtxGetter(trmcontext.DefaultManager)
 
 // CtxGetter gets Tr from trm.СtxManager by casting trm.Transaction to Tr.
 type CtxGetter struct {
-	ctxManager trm.СtxManager
+	ctxManager trm.CtxManager
 }
 
 // NewCtxGetter returns *CtxGetter to get Tr from context.Context.
-func NewCtxGetter(c trm.СtxManager) *CtxGetter {
+func NewCtxGetter(c trm.CtxManager) *CtxGetter {
 	return &CtxGetter{ctxManager: c}
 }
 

--- a/drivers/sql/context.go
+++ b/drivers/sql/context.go
@@ -13,11 +13,11 @@ var DefaultCtxGetter = NewCtxGetter(trmcontext.DefaultManager)
 
 // CtxGetter gets Tr from trm.СtxManager by casting trm.Transaction to Tr.
 type CtxGetter struct {
-	ctxManager trm.СtxManager
+	ctxManager trm.CtxManager
 }
 
 // NewCtxGetter returns *CtxGetter to get Tr from context.Context.
-func NewCtxGetter(c trm.СtxManager) *CtxGetter {
+func NewCtxGetter(c trm.CtxManager) *CtxGetter {
 	return &CtxGetter{ctxManager: c}
 }
 

--- a/drivers/sqlx/context.go
+++ b/drivers/sqlx/context.go
@@ -14,11 +14,11 @@ var DefaultCtxGetter = NewCtxGetter(trmcontext.DefaultManager)
 
 // CtxGetter gets Tr from trm.СtxManager by casting trm.Transaction to Tr.
 type CtxGetter struct {
-	ctxManager trm.СtxManager
+	ctxManager trm.CtxManager
 }
 
 // NewCtxGetter returns *CtxGetter to get Tr from context.Context.
-func NewCtxGetter(c trm.СtxManager) *CtxGetter {
+func NewCtxGetter(c trm.CtxManager) *CtxGetter {
 	return &CtxGetter{ctxManager: c}
 }
 

--- a/trm/context.go
+++ b/trm/context.go
@@ -11,7 +11,7 @@ type CtxKey interface{}
 type CtxGetter func(ctx context.Context) Transaction
 
 // СtxManager sets and gets a Transaction in/from context.Context.
-type СtxManager interface {
+type CtxManager interface {
 	// Default gets Transaction from context.Context by default CtxKey.
 	Default(ctx context.Context) Transaction
 	// SetDefault sets.Transaction in context.Context by default CtxKey.

--- a/trm/manager/manager.go
+++ b/trm/manager/manager.go
@@ -19,7 +19,7 @@ type Opt func(*Manager) error
 type Manager struct {
 	getTransaction trm.TrFactory
 	settings       trm.Settings
-	ctxManager     trm.СtxManager
+	ctxManager     trm.CtxManager
 	log            logger
 }
 

--- a/trm/manager/option.go
+++ b/trm/manager/option.go
@@ -21,7 +21,7 @@ func WithSettings(s trm.Settings) Opt {
 }
 
 // WithCtxManager sets trm.Settings for Manager.
-func WithCtxManager(c trm.СtxManager) Opt {
+func WithCtxManager(c trm.CtxManager) Opt {
 	return func(m *Manager) error {
 		m.ctxManager = c
 


### PR DESCRIPTION
Сначала не понимал, почему автокомплит не предлагает нужный мне тип, а потом линтер сказал, что у типа есть non-ASCII символы. И было весьма неожиданно увидеть, что браузер в консоли на `'СtxManager' === 'CtxManager'` ответил false)